### PR TITLE
AGEPRO makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
+
+# Visual Studio Code IDE settings
+*.vscode

--- a/makefile
+++ b/makefile
@@ -38,7 +38,7 @@ agepro: $(OBJ_FILES)
 	$(CC) $(C_FLAGS) -o $(EXE_PATH) $^ $(MAIN_FILE) 
 
 # Cleanup  
-PHONY: .clean
+.PHONY: clean
 clean:
 	echo "[Clean] Clean Object Files"
 	-rm -f $(OBJ_FILES)

--- a/makefile
+++ b/makefile
@@ -3,6 +3,9 @@
 C_FLAGS := # -Wall -Wextra 
 CC := gcc
 
+# Include <math.h> library to compilation
+LIBS := -lm
+
 # Directories the makefile should search 
 VPATH := ./obj/ ./src/ ./bin/
 
@@ -35,7 +38,7 @@ $(OBJ_DIR)/%.o: $(SRC_DIR)/%.c
 #Compile main file, and link object files to target executable.
 agepro: $(OBJ_FILES)
 	@echo "[Info] Building Binary Executable [$(TARGET)]"
-	$(CC) $(C_FLAGS) -o $(EXE_PATH) $^ $(MAIN_FILE) 
+	$(CC) $(C_FLAGS) -o $(EXE_PATH) $^ $(MAIN_FILE) $(LIBS)
 
 # Cleanup  
 .PHONY: clean

--- a/makefile
+++ b/makefile
@@ -1,0 +1,45 @@
+# Compiler Options
+# Enable -Wall -Wextra for GCC compiler warning messages
+C_FLAGS := # -Wall -Wextra 
+CC := gcc
+
+# Directories the makefile should search 
+VPATH := ./obj/ ./src/ ./bin/
+
+#TARGET binary executable 
+TARGET := AGEPRO.exe
+
+# Directory Variables
+SRC_DIR := ./src
+BIN_DIR := ./bin
+OBJ_DIR := ./obj
+EXE_PATH := $(BIN_DIR)/$(TARGET)
+
+# Source Files 
+# Header files included in src directory
+C_FILES := ranx.c boxmuller.c util.c 
+SRC_FILES := $(C_FILES:%.c=$(SRC_DIR)/%.c)
+MAIN_FILE := $(SRC_DIR)/AgePro.c
+
+# Object Files 
+OBJ_FILES := $(C_FILES:%.c=$(OBJ_DIR)/%.o)
+
+# Build 
+all: $(OBJ_DIR) agepro
+.PHONY: all
+
+#Compile Object Files for non-main source code files
+$(OBJ_DIR)/%.o: $(SRC_DIR)/%.c
+	$(CC) $(C_FLAGS) -c -o $@ $<
+ 
+#Compile main file, and link object files to target executable.
+agepro: $(OBJ_FILES)
+	@echo "[Info] Building Binary Executable [$(TARGET)]"
+	$(CC) $(C_FLAGS) -o $(EXE_PATH) $^ $(MAIN_FILE) 
+
+# Cleanup  
+PHONY: .clean
+clean:
+	echo "[Clean] Clean Object Files"
+	-rm -f $(OBJ_FILES)
+


### PR DESCRIPTION
Makefile for AGEPRO. Built using MSYS2-mingw (ucrt64).  (windows) 

Note: Visual Studio Code's terminals had issues with cleaning object files, this is due to windows powershell with no native command for `rm`. Using MSYS2-mingw or "git bash" fixes this.

This following assumes that the system and user environmental `PATH` variable is set to `C:\\msys64\\ucrt64\\bin\\`. To check if it is configured properly, open **command prompt** and type `gcc --version` or `mingw32-make --version`. 

Build AGERPRO with Makefile on AGEPRO Project root directory:
```
$ mingw32-make all -f makefile
gcc  -c -o obj/ranx.o src/ranx.c
gcc  -c -o obj/boxmuller.o src/boxmuller.c
gcc  -c -o obj/util.o src/util.c
[Info] Building Binary Executable [AGEPRO.exe]
gcc  -o ./bin/AGEPRO.exe obj/ranx.o obj/boxmuller.o obj/util.o ./src/AgePro.c
```

Clean up Object Files 
```
$ mingw32-make clean -f makefile
echo "[Clean] Clean Object Files"
[Clean] Clean Object Files
rm -f ./obj/ranx.o ./obj/boxmuller.o ./obj/util.o
```

